### PR TITLE
Fix no subjects if statistics_query mode

### DIFF
--- a/src/app/modules/gb-explore-module/gb-explore.component.html
+++ b/src/app/modules/gb-explore-module/gb-explore.component.html
@@ -11,7 +11,7 @@
         <span class="gb-data-selection-accordion-sub-header-3 float-left">
           <span class="gb-data-selection-emphasis-text">{{globalCount | async}} subjects</span>
         </span>
-        <span id="save-box">
+        <span id="save-box" *ngIf="!isBiorefMode && isGlobalCountOrPatientList">
           <input [(ngModel)]="cohortName" pInputText (keydown)="saveIfEnter($event)" placeholder="Cohort name" (drop)="preventDefault($event)"/>
           <span>&nbsp;</span>
           <button

--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -138,7 +138,7 @@ export class GbExploreComponent implements AfterViewChecked {
   }
 
   get isGlobalCountOrPatientList(): boolean {
-    return this.keycloakService.isUserInRole('global_count') || 
+    return this.keycloakService.isUserInRole('global_count') ||
             this.keycloakService.isUserInRole('patient_list');
   }
 

--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -9,6 +9,7 @@
  */
 
 import { AfterViewChecked, ChangeDetectorRef, Component, Input } from '@angular/core';
+import { KeycloakService } from 'keycloak-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AppConfig } from 'src/app/config/app.config';
@@ -46,7 +47,8 @@ export class GbExploreComponent implements AfterViewChecked {
     private cohortService: CohortService,
     public constraintService: ConstraintService,
     private changeDetectorRef: ChangeDetectorRef,
-    private exploreStatisticsService: ExploreStatisticsService) {
+    private exploreStatisticsService: ExploreStatisticsService,
+    private keycloakService: KeycloakService) {
     this.queryService.lastSuccessfulSet.subscribe(resIDs => {
       this.lastSuccessfulSet = resIDs
     })
@@ -133,6 +135,11 @@ export class GbExploreComponent implements AfterViewChecked {
 
   get isBiorefMode(): boolean {
     return this.config.getConfig('isBiorefMode');
+  }
+
+  get isGlobalCountOrPatientList(): boolean {
+    return this.keycloakService.isUserInRole('global_count') || 
+            this.keycloakService.isUserInRole('patient_list');
   }
 
 

--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -74,8 +74,7 @@ export class GbExploreComponent implements AfterViewChecked {
 
 
     if (this.userHasExploreStatsRole()) {
-      this.execExploreStatisticsQuery(event)
-      return
+      this.execExploreStatisticsQuery(event);
     }
 
 

--- a/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
+++ b/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
@@ -34,7 +34,7 @@
       </p-accordionTab>
     </div>
 
-    <div>
+    <div *ngIf="!isBiorefMode && isGlobalCountOrPatientList">
       <p-accordionTab header="Saved Cohorts" [selected]="true">
         <gb-cohorts></gb-cohorts>
       </p-accordionTab>

--- a/src/app/modules/gb-side-panel-module/gb-side-panel.component.ts
+++ b/src/app/modules/gb-side-panel-module/gb-side-panel.component.ts
@@ -48,7 +48,7 @@ export class GbSidePanelComponent {
     }
 
     get isGlobalCountOrPatientList(): boolean {
-      return this.keycloakService.isUserInRole('global_count') || 
+      return this.keycloakService.isUserInRole('global_count') ||
               this.keycloakService.isUserInRole('patient_list');
     }
 

--- a/src/app/modules/gb-side-panel-module/gb-side-panel.component.ts
+++ b/src/app/modules/gb-side-panel-module/gb-side-panel.component.ts
@@ -12,6 +12,8 @@ import {TermSearchService} from '../../services/term-search.service';
 import {OntologyNavbarService} from '../../services/ontology-navbar.service';
 import {SavedCohortsPatientListService} from '../../services/saved-cohorts-patient-list.service';
 import {AccordionTab} from 'primeng';
+import { AppConfig } from 'src/app/config/app.config';
+import { KeycloakService } from 'keycloak-angular';
 
 @Component({
   selector: 'gb-side-panel',
@@ -25,7 +27,9 @@ export class GbSidePanelComponent {
               public savedCohortsPatientListService: SavedCohortsPatientListService,
               public ontologyNavbarService: OntologyNavbarService,
               public termSearchService: TermSearchService,
-              public renderer: Renderer2) { }
+              public renderer: Renderer2,
+              private config: AppConfig,
+              private keycloakService: KeycloakService) { }
 
     ngAfterViewInit() {
       this.termSearchService.searchResultObservable.subscribe(searchResults => {
@@ -41,5 +45,14 @@ export class GbSidePanelComponent {
           });
         }, 0);
       });
+    }
+
+    get isGlobalCountOrPatientList(): boolean {
+      return this.keycloakService.isUserInRole('global_count') || 
+              this.keycloakService.isUserInRole('patient_list');
+    }
+
+    get isBiorefMode(): boolean {
+      return this.config.getConfig('isBiorefMode');
     }
 }

--- a/src/app/services/authentication.service.ts
+++ b/src/app/services/authentication.service.ts
@@ -18,7 +18,7 @@ export class AuthenticationService {
   static readonly GECO_PROJECT_CREATOR_ROLE = 'project_creator';
   static readonly GECO_PATIENT_LIST_ROLE = 'patient_list';
   static readonly GECO_GLOBAL_COUNT_ROLE = 'global_count';
-  static readonly GECO_SURVIVAL_ANALYSIS_ROLE = 'project_creator';
+  static readonly GECO_SURVIVAL_ANALYSIS_ROLE = 'survival_query';
   static readonly GECO_EXPLORE_STATS_ROLE = 'statistics_query';
 
   constructor(private config: AppConfig,

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -86,7 +86,7 @@ export class TreeNodeService {
 
               this.processTreeNodes(treeNodes, this.constraintService);
               treeNodes.forEach((node) => this.rootTreeNodes.push(node));
-              this.config.setConfig('isBiorefMode', this.keycloakService.isUserInRole(AuthenticationService.GECO_EXPLORE_STATS_ROLE));
+              this.config.setConfig('isBiorefMode', !this.keycloakService.isUserInRole(AuthenticationService.GECO_SURVIVAL_ANALYSIS_ROLE));
               this._isLoading = false;
               resolve();
             },


### PR DESCRIPTION
As @f-marino pointed, in Bioref mode, it doesn't run the regular explore_query, so it's impossible to save cohorts (0 subject).

Now it'll run both query (statistics_query & explore_query) so it's possible to save cohorts.