### PR TITLE
Network health

### DIFF
--- a/src/app/models/api-response-models/medco-network/api-network-status-metadata.ts
+++ b/src/app/models/api-response-models/medco-network/api-network-status-metadata.ts
@@ -1,0 +1,11 @@
+type NodeStatus = {
+  node: string;
+  status: "ok" | "nok"
+};
+
+type FromNodeReturn = {
+  from: string;
+  statuses: NodeStatus[];
+};
+
+export type ApiNetworkStatusMetadata = FromNodeReturn[];

--- a/src/app/models/api-response-models/medco-network/api-network-status-metadata.ts
+++ b/src/app/models/api-response-models/medco-network/api-network-status-metadata.ts
@@ -1,11 +1,11 @@
-type NodeStatus = {
+interface NodeStatus {
   node: string;
-  status: "ok" | "nok"
-};
+  status: 'ok' | 'nok'
+}
 
-type FromNodeReturn = {
+interface FromNodeReturn {
   from: string;
   statuses: NodeStatus[];
-};
+}
 
 export type ApiNetworkStatusMetadata = FromNodeReturn[];

--- a/src/app/models/api-response-models/medco-network/api-node-metadata.ts
+++ b/src/app/models/api-response-models/medco-network/api-node-metadata.ts
@@ -4,4 +4,7 @@ export class ApiNodeMetadata {
   current: boolean;
   isUp?: boolean;
   isChecked?: boolean;
+  organization: {
+    country: string;
+  }
 }

--- a/src/app/models/api-response-models/medco-network/api-node-metadata.ts
+++ b/src/app/models/api-response-models/medco-network/api-node-metadata.ts
@@ -2,4 +2,6 @@ export class ApiNodeMetadata {
   name: string;
   url: string;
   current: boolean;
+  isUp?: boolean;
+  isChecked?: boolean;
 }

--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -13,7 +13,7 @@ import { KeycloakService } from 'keycloak-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AppConfig } from 'src/app/config/app.config';
-import { Cohort } from 'src/app/models/cohort-models/cohort';
+import { MedcoNetworkService } from 'src/app/services/api/medco-network.service';
 import { AuthenticationService } from 'src/app/services/authentication.service';
 import { ExploreStatisticsService } from 'src/app/services/explore-statistics.service';
 import { OperationType } from '../../models/operation-models/operation-types';
@@ -48,6 +48,7 @@ export class GbExploreComponent implements AfterViewChecked {
     public constraintService: ConstraintService,
     private changeDetectorRef: ChangeDetectorRef,
     private exploreStatisticsService: ExploreStatisticsService,
+    private medcoNetworkService: MedcoNetworkService,
     private keycloakService: KeycloakService) {
     this.queryService.lastSuccessfulSet.subscribe(resIDs => {
       this.lastSuccessfulSet = resIDs
@@ -126,6 +127,10 @@ export class GbExploreComponent implements AfterViewChecked {
 
   get hasConstraint(): boolean {
     return this.constraintService.hasConstraint().valueOf()
+  }
+
+  get allNodesIsUp(): boolean {
+    return this.medcoNetworkService.nodes.every((e) => e.isUp)
   }
 
   get isBiorefMode(): boolean {

--- a/src/app/modules/gb-select-project-module/gb-select-project.component.ts
+++ b/src/app/modules/gb-select-project-module/gb-select-project.component.ts
@@ -36,6 +36,7 @@ interface Project {
 export class GbSelectProjectComponent {
   private projectList: Project[] = [];
   private _selectedProjectIndex = -1;
+  private _setIntervalTimeout = null;
 
   constructor(
     private config: AppConfig,
@@ -88,7 +89,14 @@ export class GbSelectProjectComponent {
     this.queryService.clearAll();
     this.treeNodeService.exploreTreeNode();
     this.navbarService.navigateToExploreTab();
+
+    if (this._setIntervalTimeout) {
+      clearInterval(this._setIntervalTimeout);
+    }
     this.medcoNetworkService.getNetworkStatus();
+    this._setIntervalTimeout = setInterval(() => {
+      this.medcoNetworkService.getNetworkStatus();
+    }, 1000 * 60) 
   }
 
   public getProjectList() {

--- a/src/app/modules/gb-select-project-module/gb-select-project.component.ts
+++ b/src/app/modules/gb-select-project-module/gb-select-project.component.ts
@@ -36,7 +36,6 @@ interface Project {
 export class GbSelectProjectComponent {
   private projectList: Project[] = [];
   private _selectedProjectIndex = -1;
-  private _projectName;
 
   constructor(
     private config: AppConfig,
@@ -89,6 +88,7 @@ export class GbSelectProjectComponent {
     this.queryService.clearAll();
     this.treeNodeService.exploreTreeNode();
     this.navbarService.navigateToExploreTab();
+    this.medcoNetworkService.getNetworkStatus();
   }
 
   public getProjectList() {

--- a/src/app/modules/gb-select-project-module/gb-select-project.component.ts
+++ b/src/app/modules/gb-select-project-module/gb-select-project.component.ts
@@ -96,7 +96,7 @@ export class GbSelectProjectComponent {
     this.medcoNetworkService.getNetworkStatus();
     this._setIntervalTimeout = setInterval(() => {
       this.medcoNetworkService.getNetworkStatus();
-    }, 1000 * 60) 
+    }, 1000 * 60);
   }
 
   public getProjectList() {

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.css
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.css
@@ -1,7 +1,6 @@
 .participant-node {
     color: lightgrey;
     margin-top: 4px;
-    padding-left: 16px;
     width: fit-content;
 }
 

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.css
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.css
@@ -7,3 +7,8 @@
 .node_is_up {
     color: black;
 }
+
+.ui-button-secondary.no-background {
+    background-color: transparent !important;
+    box-shadow: none !important;
+}

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.css
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.css
@@ -1,1 +1,10 @@
+.participant-node {
+    color: lightgrey;
+    margin-top: 4px;
+    padding-left: 16px;
+    width: fit-content;
+}
 
+.node_is_up {
+    color: black;
+}

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
@@ -2,7 +2,12 @@
   <span>Project: {{projectName}}</span>
   <br />
   <br />
-  <span>Connected participants:</span>
+  <span>Connected participants
+    <button pButton class="ui-button-secondary no-background" [disabled]="isRefreshingNodes"
+      [ngStyle]="{'color': isRefreshingNodes ? 'var(--gb-light-light-clinical-green)':'var(--gb-ti-main-color)'}"
+      type="button" pTooltip="Refresh participants" tooltipPosition="top" (click)="refreshNodes()" icon="fa fa-refresh">
+  </button>
+  </span>
   <ul>
     <li *ngFor="let node of getNodes; let nodeIdx = index" [pTooltip]="getTooltipMessage(node.name)" class="participant-node" [ngClass]="{'node_is_up': isNodeUp(node.name), 'not-in-project': !isNodeInProject(node.name)}">
       {{node.name}}

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
@@ -1,7 +1,7 @@
 <div>
   <span>Connected participants:</span>
-  <div *ngFor="let node of getNodes; let nodeIdx = index" [pTooltip]="!node.isUp ? 'This node seems to be down' : null" class="participant-node" [ngClass]="{'node_is_up': !!node.isUp}" title="{{node.url}} | {{node.organization.country}}">
-    <input (click)="onChangeNode($event)" type="checkbox" name="{{node.name}}" [attr.checked]="node.isChecked ? true : null" [attr.disabled]="!node.isUp || node.current ? true : null" />
+  <div *ngFor="let node of getNodes; let nodeIdx = index" [pTooltip]="getTooltipMessage(node.name)" class="participant-node" [ngClass]="{'node_is_up': !!node.isUp}">
+    <input (click)="onChangeNode($event)" type="checkbox" name="{{node.name}}" [attr.checked]="node.isChecked ? true : null" [attr.disabled]="node.checkboxDisabled" />
     {{node.name}}
     <span *ngIf="node.current"> (you)</span>
     <span *ngIf="hasPerSiteCounts && queryResults|async">: {{(queryResults|async).perSiteCounts[nodeIdx]}} subjects</span>

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
@@ -1,9 +1,10 @@
 <div>
   <span>Connected participants:</span>
-  <ul>
-    <li *ngFor="let node of getNodes; let nodeIdx = index" title="{{node.url}} | {{node.organization.country}}">
-      {{node.name}}<span *ngIf="hasPerSiteCounts && queryResults|async">: {{(queryResults|async).perSiteCounts[nodeIdx]}} subjects</span>
-    </li>
-  </ul>
-  <div>Total: {{globalCount | async}} subjects</div>
+  <div *ngFor="let node of getNodes; let nodeIdx = index" [pTooltip]="!node.isUp ? 'This node seems to be down' : null" class="participant-node" [ngClass]="{'node_is_up': !!node.isUp}" title="{{node.url}} | {{node.organization.country}}">
+    <input (click)="onChangeNode($event)" type="checkbox" name="{{node.name}}" [attr.checked]="node.isChecked ? true : null" [attr.disabled]="!node.isUp || node.current ? true : null" />
+    {{node.name}}
+    <span *ngIf="node.current"> (you)</span>
+    <span *ngIf="hasPerSiteCounts && queryResults|async">: {{(queryResults|async).perSiteCounts[nodeIdx]}} subjects</span>
+  </div>
+  <div style="margin-top: 16px;">Total: {{globalCount | async}} subjects</div>
 </div>

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
@@ -3,11 +3,12 @@
   <br />
   <br />
   <span>Connected participants:</span>
-  <div *ngFor="let node of getNodes; let nodeIdx = index" [pTooltip]="getTooltipMessage(node.name)" class="participant-node" [ngClass]="{'node_is_up': !!node.isUp, 'not-in-project': !isNodeInProject(node.name)}">
-    <input (click)="onChangeNode($event)" type="checkbox" name="{{node.name}}" [attr.checked]="node.isChecked && isNodeInProject(node.name) ? true : null" [attr.disabled]="node.checkboxDisabled" />
-    {{node.name}}
-    <span *ngIf="node.current"> (you)</span>
-    <span *ngIf="isNodeInProject(node.name) && hasPerSiteCounts && queryResults|async">: {{(queryResults|async).perSiteCounts[nodeIdx]}} subjects</span>
-  </div>
+  <ul>
+    <li *ngFor="let node of getNodes; let nodeIdx = index" [pTooltip]="getTooltipMessage(node.name)" class="participant-node" [ngClass]="{'node_is_up': isNodeUp(node.name), 'not-in-project': !isNodeInProject(node.name)}">
+      {{node.name}}
+      <span *ngIf="node.current"> (you)</span>
+      <span *ngIf="isNodeInProject(node.name) && hasPerSiteCounts && queryResults|async">: {{(queryResults|async).perSiteCounts[nodeIdx]}} subjects</span>
+    </li>
+  </ul>
   <div style="margin-top: 16px;">Total: {{globalCount | async}} subjects</div>
 </div>

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -53,10 +53,10 @@ export class GbSummaryComponent {
 
     const networkStatus = this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName);
     let titleStr = `${nodeName} (${node.url} | ${node.organization.country})`;
-    
+
     if (networkStatus) {
       titleStr += ` is connected to:\n  \
-              ${networkStatus.statuses.reduce((result, status) => `${result}\n${status.node}: ${status.status}`, "")}
+              ${networkStatus.statuses.reduce((result, status) => `${result}\n${status.node}: ${status.status}`, '')}
       `;
     }
     return titleStr;

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -44,6 +44,24 @@ export class GbSummaryComponent {
     return this.medcoNetworkService.nodes;
   }
 
+  getTooltipMessage(nodeName: string) {
+    const node = this.getNodes.find((e) => e.name === nodeName);
+
+    if (!node.isUp) {
+      return `This node (${node.name} | ${node.url} | ${node.organization.country}) seems to be down`
+    }
+
+    const networkStatus = this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName);
+    let titleStr = `${nodeName} (${node.url} | ${node.organization.country})`;
+    
+    if (networkStatus) {
+      titleStr += ` is connected to:\n  \
+              ${networkStatus.statuses.reduce((result, status) => `${result}\n${status.node}: ${status.status}`, "")}
+      `;
+    }
+    return titleStr;
+  }
+
   onChangeNode(e) {
     this.medcoNetworkService.setNodeChecked(e.srcElement.name, e.srcElement.checked);
   }

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -66,12 +66,12 @@ export class GbSummaryComponent {
               ${networkStatus.statuses.reduce((result, status) => `${result}\n${status.node}: ${status.status}`, '')}
       `;
     } else {
-      titleStr += " seems to be down."
+      titleStr += ' seems to be down.'
     }
     return titleStr;
   }
 
-  
+
   onChangeNode(e) {
     this.medcoNetworkService.setNodeChecked(e.srcElement.name, e.srcElement.checked);
   }

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -22,6 +22,8 @@ import { AppConfig } from 'src/app/config/app.config';
 })
 export class GbSummaryComponent {
 
+  private _isRefreshingNodes = false;
+
   constructor(private queryService: QueryService,
               private medcoNetworkService: MedcoNetworkService,
               private config: AppConfig) {
@@ -50,6 +52,14 @@ export class GbSummaryComponent {
     return this.medcoNetworkService.nodes;
   }
 
+  get isRefreshingNodes() {
+    return this._isRefreshingNodes;
+  }
+
+  set isRefreshingNodes(value: boolean) {
+    this._isRefreshingNodes = value;
+  }
+
   getTooltipMessage(nodeName: string) {
     const node = this.getNodes.find((e) => e.name === nodeName);
 
@@ -65,6 +75,13 @@ export class GbSummaryComponent {
       titleStr += ' seems to be down.'
     }
     return titleStr;
+  }
+
+  refreshNodes() {
+    this.isRefreshingNodes = true;
+    this.medcoNetworkService.getNetworkStatus().then(() => {
+      this.isRefreshingNodes = false;
+    });
   }
 
 

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -57,7 +57,7 @@ export class GbSummaryComponent {
 
     const networkStatus = this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName);
 
-    if (networkStatus) {
+    if (networkStatus?.statuses) {
       titleStr += ` is connected to:\n  \
               ${networkStatus.statuses.reduce((result, status) => `${result}\n${status.node}: ${status.status}`, '')}
       `;

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -53,10 +53,6 @@ export class GbSummaryComponent {
   getTooltipMessage(nodeName: string) {
     const node = this.getNodes.find((e) => e.name === nodeName);
 
-    if (!node.isUp) {
-      return `This node (${node.name} | ${node.url} | ${node.organization.country}) seems to be down`
-    }
-
     let titleStr = `${nodeName} (${node.url} | ${node.organization.country})`;
 
     const networkStatus = this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName);

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -57,19 +57,27 @@ export class GbSummaryComponent {
       return `This node (${node.name} | ${node.url} | ${node.organization.country}) seems to be down`
     }
 
-    const networkStatus = this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName);
     let titleStr = `${nodeName} (${node.url} | ${node.organization.country})`;
+
+    const networkStatus = this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName);
 
     if (networkStatus) {
       titleStr += ` is connected to:\n  \
               ${networkStatus.statuses.reduce((result, status) => `${result}\n${status.node}: ${status.status}`, '')}
       `;
+    } else {
+      titleStr += " seems to be down."
     }
     return titleStr;
   }
 
+  
   onChangeNode(e) {
     this.medcoNetworkService.setNodeChecked(e.srcElement.name, e.srcElement.checked);
+  }
+
+  isNodeUp(nodeName: string) {
+    return !!this.medcoNetworkService.networkStatus?.find((e) => e.from === nodeName).statuses;
   }
 
   isNodeInProject(nodeName: string) {

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -43,4 +43,8 @@ export class GbSummaryComponent {
   get getNodes() {
     return this.medcoNetworkService.nodes;
   }
+
+  onChangeNode(e) {
+    this.medcoNetworkService.setNodeChecked(e.srcElement.name, e.srcElement.checked);
+  }
 }

--- a/src/app/services/api/medco-network.service.ts
+++ b/src/app/services/api/medco-network.service.ts
@@ -53,7 +53,7 @@ export class MedcoNetworkService {
               isUp,
               isChecked: isUp
             }});
-            
+
         console.log(`Loaded nodes: ${metadata.nodes.map((a) => a.name).join(', ')}`);
         resolve();
       }, (err) => {
@@ -84,9 +84,9 @@ export class MedcoNetworkService {
     return this._networkStatus;
   }
 
-  
+
   //  ------------------- others ----------------------
-  
+
   public setNodeChecked(name: string, isChecked: boolean) {
     this._nodes = this._nodes.map((node) => ({
       ...node,

--- a/src/app/services/api/medco-network.service.ts
+++ b/src/app/services/api/medco-network.service.ts
@@ -107,9 +107,12 @@ export class MedcoNetworkService {
    * Sets the MedCo network status metadata.
    */
   getNetworkStatus() {
-    const urlPart = `projects/${this.config.projectId}/network-status`;
-    this.apiEndpointService.getCall(urlPart, false, undefined, false).subscribe((metadata) => {
-      this._networkStatus = metadata;
+    return new Promise<void>((resolve, reject) => {
+      const urlPart = `projects/${this.config.projectId}/network-status`;
+      this.apiEndpointService.getCall(urlPart, false, undefined, false).subscribe((metadata) => {
+        this._networkStatus = metadata;
+        resolve();
+      });
     });
   }
 }

--- a/src/app/services/api/medco-network.service.ts
+++ b/src/app/services/api/medco-network.service.ts
@@ -43,17 +43,7 @@ export class MedcoNetworkService {
 
       this.getNetwork().subscribe((metadata) => {
         this._networkPubKey = metadata['public-key'];
-        this._nodes = metadata.nodes
-          .sort(({ current }) => +current)
-          .map((node) => {
-            const isUp = true;
-            const checkboxDisabled = true;
-            return {
-              ...node,
-              checkboxDisabled,
-              isUp,
-              isChecked: isUp
-            }});
+        this._nodes = metadata.nodes.sort(({ current }) => +current);
 
         console.log(`Loaded nodes: ${metadata.nodes.map((a) => a.name).join(', ')}`);
         resolve();

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -83,7 +83,6 @@ export class TreeNodeService {
           .find((project) => project.name === 'i2b2');
         if (i2b2Project && i2b2Project.dataSourceId) {
           console.log('Found project id', i2b2Project.uniqueId);
-          this.medcoNetworkService.getNetworkStatus();
           resolve();
         } else {
           this._isNoi2b2Datasource = true;

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -28,6 +28,7 @@ import { ConfirmationService } from 'primeng';
 import { KeycloakService } from 'keycloak-angular';
 import { MessageHelper } from '../utilities/message-helper';
 import { AuthenticationService } from './authentication.service';
+import { MedcoNetworkService } from './api/medco-network.service';
 
 @Injectable()
 export class TreeNodeService {
@@ -45,6 +46,7 @@ export class TreeNodeService {
   private apiEndpointService: ApiEndpointService;
   private confirmationService: ConfirmationService;
   private keycloakService: KeycloakService;
+  private medcoNetworkService: MedcoNetworkService;
 
   constructor(private injector: Injector) {}
 
@@ -59,6 +61,7 @@ export class TreeNodeService {
       this.constraintService = this.injector.get(ConstraintService);
       this.apiEndpointService = this.injector.get(ApiEndpointService);
       this.confirmationService = this.injector.get(ConfirmationService);
+      this.medcoNetworkService = this.injector.get(MedcoNetworkService);
 
       this.constraintService.conceptLabels = [];
 
@@ -78,6 +81,7 @@ export class TreeNodeService {
         if (i2b2Project && i2b2Project.dataSourceId) {
           console.log('Found project id', i2b2Project.uniqueId);
           this.config.projectId = i2b2Project.uniqueId;
+          this.medcoNetworkService.getNetworkStatus();
           this.exploreSearchService.exploreSearchConceptChildren('/').subscribe(
             (treeNodes: TreeNode[]) => {
               // reset concepts and concept constraints


### PR DESCRIPTION
Implemented solution look like this:

By hovering a node we have the details, and the confirmation that it can reach each other's nodes:
![image](https://user-images.githubusercontent.com/10889224/186458968-2ae8f4de-3a99-4345-b190-93b82473f183.png)

If one node is not reachable, it will appear like this (and not checkable):
![image](https://user-images.githubusercontent.com/10889224/186458624-fcb3c96d-6b96-4c90-8baf-72a2a3df9a92.png)


The boxes are 100% of the time "disabled" (meaning we cannot interact with them). To properly be able to control them we need [this PR](https://github.com/tuneinsight/app/pull/455/files) to be finished first I think.

We can implements that on the front-end later, in another GB PR.