### PR TITLE
Allow displaying 1 column when there's 1 graph addressing #50

### DIFF
--- a/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
+++ b/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
@@ -85,7 +85,7 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
 
 
   private exportPDF() {
-    
+
     if (this.refIntervalsComponents === undefined || this.refIntervalsComponents.length <= 0) {
       throw ErrorHelper.handleNewError('Cannot export pdf yet. Execute a query firsthand.');
     }

--- a/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
+++ b/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
@@ -85,10 +85,15 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
 
 
   private exportPDF() {
-    const pdf = new PDF(2, 8, -3);
+    
     if (this.refIntervalsComponents === undefined || this.refIntervalsComponents.length <= 0) {
       throw ErrorHelper.handleNewError('Cannot export pdf yet. Execute a query firsthand.');
     }
+    let nbColumn = 1.1
+    if (this.refIntervalsComponents.length > 1) {
+      nbColumn = 2
+    }
+    const pdf = new PDF(nbColumn, 8, -3);
 
     const date = new Date();
     pdf.addOneLineText('Date of export (d/m/y): ' + date.getDate() + '/' + (date.getMonth() + 1) + '/' + date.getUTCFullYear(), 0);


### PR DESCRIPTION
Fixing #50 

Before:
![Screenshot from 2022-09-13 22-30-12](https://user-images.githubusercontent.com/725345/190003353-6cd616c4-766b-46c1-b312-89e592d400a1.png)

After:
![Screenshot from 2022-09-13 22-30-58](https://user-images.githubusercontent.com/725345/190003367-5117569a-2f3f-4c8f-8391-1d9527252d7f.png)

The cut "Username" is addressed in another PR.

When there are more than 1, the behavior remains 2 columns:
![Screenshot from 2022-09-13 22-32-35](https://user-images.githubusercontent.com/725345/190003638-b2fcbcf0-2597-415b-b2c0-21173bc1c798.png)


