### PR TITLE
Fix receiving patientList for the optimized backend

### DIFF
--- a/src/app/services/api/medco-node/explore-query.service.ts
+++ b/src/app/services/api/medco-node/explore-query.service.ts
@@ -84,6 +84,7 @@ export class ExploreQueryService {
         targetPublicKey: publicKey,
         parameters: {
           id: queryId,
+          patientList: haveRightsForPatientList,
           definition: {
             selectionPanels: selectionPanels,
             sequentialPanels: sequentialPanels,


### PR DESCRIPTION
Since the [backend optimization](https://github.com/tuneinsight/geco-i2b2-data-source/pull/37), the backend is now expecting a PatientList bool parameter.