### PR TITLE
Fix survival subgroups bug and cohort items bug

### DIFF
--- a/src/app/modules/gb-explore-module/constraint-components/gb-composite-constraint/gb-composite-constraint.component.ts
+++ b/src/app/modules/gb-explore-module/constraint-components/gb-composite-constraint/gb-composite-constraint.component.ts
@@ -87,6 +87,7 @@ export class GbCompositeConstraintComponent extends GbConstraintComponent implem
     } else {
       const constraintCohort = new ConstraintCohort();
       constraintCohort.name = this.cohortService.selectedCohort.name;
+      constraintCohort.exploreQueryId = this.cohortService.selectedCohort.exploreQueryId;
 
       const cohortConstraint = CohortConstraint.NewCohortConstraintFromCohort(constraintCohort)
       this.droppedConstraint = cohortConstraint;

--- a/src/app/services/survival-analysis.service.ts
+++ b/src/app/services/survival-analysis.service.ts
@@ -178,9 +178,9 @@ export class SurvivalService {
           constraint: {
             queryTiming: sg.timing,
             selectionPanels: this.constraintMappingService.mapConstraint(sg.rootSelectionConstraint,
-              this.queryService.queryTiming === QueryTemporalSetting.independent),
+              this.queryService.queryTiming === QueryTemporalSetting.sameinstance),
             sequentialPanels: this.constraintMappingService.mapConstraint(sg.rootSequentialConstraint,
-              this.queryService.queryTiming === QueryTemporalSetting.independent),
+              this.queryService.queryTiming === QueryTemporalSetting.sameinstance),
             sequentialOperators: sg.rootSequentialConstraint.temporalSequence,
           }
         }


### PR DESCRIPTION
Fixing:
- subgroups were not working as expected, one of the subgroups was containing the whole cohort
- cohorts as query items did not work